### PR TITLE
Added support for CASTEP .cell files

### DIFF
--- a/webservice/structure_importers/__init__.py
+++ b/webservice/structure_importers/__init__.py
@@ -52,6 +52,10 @@ def get_structure_tuple(fileobject, fileformat):
         import ase.io.xsf
         asestructure = ase.io.xsf.read_xsf(fileobject)
         return tuple_from_ase(asestructure)
+    elif fileformat == 'castep':
+        import ase.io.castep
+        asestructure = ase.io.castep.read_castep_cell(fileobject)
+        return tuple_from_ase(asestructure)
     elif fileformat == 'qe-inp':
         from .qeinp import read_qeinp
         structure_tuple = read_qeinp(fileobject)

--- a/webservice/templates/visualizer_select.html
+++ b/webservice/templates/visualizer_select.html
@@ -68,6 +68,7 @@
             <option value="qe-inp">Quantum ESPRESSO input</option>
             <option value="vasp">VASP POSCAR</option>
             <option value="xsf">XCrySDen (XSF)</option>
+            <option value="castep">CASTEP (.cell)</option>
 	  </select>
 	</div> 
       </div>


### PR DESCRIPTION
What we discussed some time ago - added support for seekpath to load also CASTEP .cell files. No other types are supported for now.