### PR TITLE
Add link to format specifications/docs

### DIFF
--- a/webservice/templates/visualizer_base.html
+++ b/webservice/templates/visualizer_base.html
@@ -532,6 +532,7 @@
         <div id="accordion">
         <h3>Quantum ESPRESSO pw.x input</h3>
         <div>
+          <div style="font-size: small;"><a href="https://www.quantum-espresso.org/Doc/INPUT_PW.html" target="_blank">[FORMAT DESCRIPTION]</a></div>
           <p>
             <button class="clipboardbtn" data-clipboard-target="#qepwdata">
               <img src="../static/img/clippy.svg" width="12" alt="Copy to clipboard"/>&nbsp;Copy to clipboard</button>
@@ -548,6 +549,7 @@
         </div>-->
         <h3>CP2K input</h3>
         <div>
+          <div style="font-size: small;"><a href="https://manual.cp2k.org/trunk/CP2K_INPUT/FORCE_EVAL/DFT/PRINT/BAND_STRUCTURE/KPOINT_SET.html" target="_blank">[FORMAT DESCRIPTION]</a></div>
           <p>
             <button class="clipboardbtn" data-clipboard-target="#cp2kdata">
               <img src="../static/img/clippy.svg" width="12" alt="Copy to clipboard"/>&nbsp;Copy to clipboard</button>
@@ -558,6 +560,7 @@
         </div>
         <h3>CRYSTAL *.d3 input</h3>
         <div>
+          <div style="font-size: small;"><a href="http://tutorials.crystalsolutions.eu/tutorial.html?td=properties&tf=properties_tut" target="_blank">[FORMAT DESCRIPTION]</a> (see also page 263 in the <a href="http://www.crystal.unito.it/Manuals/crystal17.pdf" target="_blank">PDF manual</a>)</div>
           <p>
             <button class="clipboardbtn" data-clipboard-target="#crystaldata">
               <img src="../static/img/clippy.svg" width="12" alt="Copy to clipboard"/>&nbsp;Copy to clipboard</button>
@@ -568,6 +571,7 @@
         </div>
         <h3>VASP KPOINTS input for LDA/GGA</h3>
         <div>
+          <div style="font-size: small;"><a href="https://www.vasp.at/wiki/index.php/KPOINTS" target="_blank">[FORMAT DESCRIPTION]</a></div>
           <p>
             <button class="clipboardbtn" data-clipboard-target="#vaspggadata">
               <img src="../static/img/clippy.svg" width="12" alt="Copy to clipboard"/>&nbsp;Copy to clipboard</button>
@@ -578,6 +582,7 @@
         </div>
         <h3>VASP KPOINTS input for LDA/GGA/Hybrid/GW</h3>
         <div>
+          <div style="font-size: small;"><a href="https://www.vasp.at/wiki/index.php/KPOINTS" target="_blank">[FORMAT DESCRIPTION]</a></div>
           <p>
             <button class="clipboardbtn" data-clipboard-target="#vaspgendata">
               <img src="../static/img/clippy.svg" width="12" alt="Copy to clipboard"/>&nbsp;Copy to clipboard</button>


### PR DESCRIPTION
I'm adding a link for the various output formats
(VASP, QE, CP2K, CRYSTAL) to appropriate pages
in the respective websites.

This fixes #70