### PR TITLE
Fixing a bug in the test suite

### DIFF
--- a/seekpath/__init__.py
+++ b/seekpath/__init__.py
@@ -7,7 +7,7 @@ Author: Giovanni Pizzi, EPFL (2016-2020)
 Licence: MIT License, see LICENSE.txt file
 """
 
-__version__ = "1.9.4"
+__version__ = "1.9.5"
 __author__ = "Giovanni Pizzi, EPFL"
 __copyright__ = "Copyright (c), 2016-2020, Giovanni Pizzi, EPFL (Theory and Simulation of Materials (THEOS) and National Centre for Computational Design and Discovery of Novel Materials (NCCR MARVEL)), Switzerland."
 __credits__ = ["Yoyo Hinuma"]

--- a/seekpath/brillouinzone/test_brillouinzone.py
+++ b/seekpath/brillouinzone/test_brillouinzone.py
@@ -59,7 +59,7 @@ def is_same_face(f1, f2):
     if found:
         return True
     # Try also reversed order
-    indices = (-(np.arange(len(f2)) + shift)) % len(f2)
+    indices = (-np.arange(len(f2)) + shift) % len(f2)
     err = np.abs(np.array(f1) - np.array(f2)[indices]).mean()
     found = err < threshold
     return found


### PR DESCRIPTION
I had thought about the possibility that the order of
the faces (in the Brillouin zone code) was random, and
also that a face could be returned with points in
reversed order (i.e., upside down); but the test to check
this case had a bug (that probably was never spotted
because until now the order was the same as in my test).

This fixes #78