### PR TITLE
Treatment for spglib v2.5.0 DeprecationWarning

### DIFF
--- a/seekpath/hpkot/__init__.py
+++ b/seekpath/hpkot/__init__.py
@@ -144,6 +144,7 @@ def get_path(
         eval_expr,
         eval_expr_simple,
         get_cell_params,
+        get_dot_access_dataset,
         get_path_data,
         get_reciprocal_cell_rows,
         get_real_cell_from_reciprocal_rows,
@@ -162,22 +163,24 @@ def get_path(
 
     # Symmetry analysis by SPGlib, get crystallographic lattice,
     # and cell parameters for this lattice
-    dataset = spglib.get_symmetry_dataset(
-        structure_internal, symprec=symprec, angle_tolerance=angle_tolerance
+    dataset = get_dot_access_dataset(
+        spglib.get_symmetry_dataset(
+            structure_internal, symprec=symprec, angle_tolerance=angle_tolerance
+        )
     )
     if dataset is None:
         raise SymmetryDetectionError(
             "Spglib could not detect the symmetry of the system"
         )
-    conv_lattice = dataset["std_lattice"]
-    conv_positions = dataset["std_positions"]
-    conv_types = dataset["std_types"]
+    conv_lattice = dataset.std_lattice
+    conv_positions = dataset.std_positions
+    conv_types = dataset.std_types
     a, b, c, cosalpha, cosbeta, cosgamma = get_cell_params(conv_lattice)
-    spgrp_num = dataset["number"]
+    spgrp_num = dataset.number
     # This is the transformation from the original to the crystallographic
     # conventional (called std in spglib)
     #  Lattice^{crystallographic_bravais} = L^{original} * transf_matrix
-    transf_matrix = dataset["transformation_matrix"]
+    transf_matrix = dataset.transformation_matrix
     volume_conv_wrt_original = np.linalg.det(transf_matrix)
 
     # Get the properties of the spacegroup, needed to get the bravais_lattice
@@ -431,7 +434,7 @@ def get_path(
     else:
         raise ValueError(
             "Unknown type '{}' for spacegroup {}".format(
-                bravais_lattice, dataset["number"]
+                bravais_lattice, dataset.number
             )
         )
 
@@ -515,7 +518,7 @@ def get_path(
         #'transformation_matrix': transf_matrix,
         "volume_original_wrt_conv": volume_conv_wrt_original,
         "volume_original_wrt_prim": volume_conv_wrt_original * np.linalg.det(invP),
-        "spacegroup_number": dataset["number"],
-        "spacegroup_international": dataset["international"],
-        "rotation_matrix": dataset["std_rotation_matrix"],
+        "spacegroup_number": dataset.number,
+        "spacegroup_international": dataset.international,
+        "rotation_matrix": dataset.std_rotation_matrix,
     }

--- a/seekpath/hpkot/spg_mapping.py
+++ b/seekpath/hpkot/spg_mapping.py
@@ -131,13 +131,14 @@ def get_spgroup_data_realtime():
     """
     import json
     import spglib
+    from .tools import get_dot_access_dataset
 
     info = {}
     for hall_n in range(1, 531):
-        data = spglib.get_spacegroup_type(hall_n)
-        number = data["number"]
-        int_short = data["international_short"]
-        pg_int = data["pointgroup_international"]
+        data = get_dot_access_dataset(spglib.get_spacegroup_type(hall_n))
+        number = data.number
+        int_short = data.international_short
+        pg_int = data.pointgroup_international
 
         if number not in info:
             info[int(number)] = (

--- a/seekpath/hpkot/tools.py
+++ b/seekpath/hpkot/tools.py
@@ -1,4 +1,5 @@
 """Various utilities."""
+
 import numpy
 import numpy.linalg
 from math import sqrt
@@ -250,6 +251,35 @@ def check_spglib_version():
         )
 
     return spglib
+
+
+def get_dot_access_dataset(dataset):
+    """Return dataset with dot access.
+
+    From spglib 2.5, dataset is returned as dataclass.
+    To emulate it for older versions, this function is used.
+
+    """
+    import spglib
+
+    try:
+        version = spglib.__version__
+    except NameError:
+        version = "1.8.0"  # or older, version was introduced only recently
+
+    version_pieces = tuple(int(v) for v in version.split(".")[:3])
+    try:
+        if len(version_pieces) < 3:
+            raise ValueError
+    except ValueError:
+        raise ValueError("Unable to parse version number")
+
+    if version_pieces < (2, 5, 0):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(**dataset)
+    else:
+        return dataset
 
 
 def get_cell_params(cell):


### PR DESCRIPTION
From spglib v2.5.0, `spglib.get_symmetry_dataset()` and `spglib.get_spacegroup_type()` return kinds of dataclass, and dot access instead of dict key is recommended. Therefore, the dict access emits DeprecationWarning. 

https://spglib.readthedocs.io/en/stable/api/python-api/spglib/spglib.html#spglib.SpglibDataset
https://spglib.readthedocs.io/en/stable/api/python-api/spglib/spglib.html#spglib.SpaceGroupType

This PR is to prevent it. I added a function `get_dot_access_dataset`, which mimics dot access for those dictionary for spglib < v2.5.0.