### PR TITLE
fix missing entrypoint on tests

### DIFF
--- a/tests/test_hpkot_get_primitive.py
+++ b/tests/test_hpkot_get_primitive.py
@@ -102,3 +102,7 @@ class TestGetPrimitive(unittest.TestCase):
             ),
             0.0,
         )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_paths_hpkot.py
+++ b/tests/test_paths_hpkot.py
@@ -1148,3 +1148,7 @@ class TestExplicitPaths_Orig_Cell(unittest.TestCase):
             np.testing.assert_array_almost_equal(
                 k_abs, k_abs_standard @ res_standard['rotation_matrix']
             )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Currently only one of the test files has a cli entry point (name == main). This is confusing as only one of the tests can be run using `python tests/${TESTNAME}` but the others pass silently. 

This commit adds the same access point to the test files that are missing them.